### PR TITLE
Fix Akka.Persistence.Azure.Hosting health checks and adopt unified API

### DIFF
--- a/src/Akka.Persistence.Azure.Hosting/AzurePersistenceExtensions.cs
+++ b/src/Akka.Persistence.Azure.Hosting/AzurePersistenceExtensions.cs
@@ -69,11 +69,8 @@ namespace Akka.Persistence.Azure.Hosting
                 AutoInitialize = autoInitialize,
                 TableName = tableName
             };
-            
-            if (eventAdapterConfigurator != null)
-                eventAdapterConfigurator(options.Adapters);
-            
-            return WithAzureTableJournal(builder, options);
+
+            return builder.WithJournal(options, eventAdapterConfigurator);
         }
 
         /// <summary>
@@ -136,11 +133,8 @@ namespace Akka.Persistence.Azure.Hosting
                 AutoInitialize = autoInitialize,
                 TableName = tableName
             };
-            
-            if (eventAdapterConfigurator is { })
-                eventAdapterConfigurator(options.Adapters);
-            
-            return WithAzureTableJournal(builder, options);
+
+            return builder.WithJournal(options, eventAdapterConfigurator);
         }
 
         /// <summary>
@@ -188,11 +182,8 @@ namespace Akka.Persistence.Azure.Hosting
                 AutoInitialize = autoInitialize,
                 TableName = tableName
             };
-            
-            if (eventAdapterConfigurator is { })
-                eventAdapterConfigurator(options.Adapters);
-            
-            return WithAzureTableJournal(builder, options);
+
+            return builder.WithJournal(options, eventAdapterConfigurator);
         }
 
         /// <summary>
@@ -287,11 +278,11 @@ namespace Akka.Persistence.Azure.Hosting
             // PUSH DEFAULT CONFIG TO END
             builder.AddHocon(AzurePersistence.DefaultConfig, HoconAddMode.Append);
 
-            if (eventAdapterConfigurator != null) // configure event adapters
+            // Event adapters should be configured through options-based methods instead
+            if (eventAdapterConfigurator != null)
             {
                 var journalOptions = new AzureTableStorageJournalOptions(true, "azure-table");
-                eventAdapterConfigurator(journalOptions.Adapters);
-                builder.AddHocon(journalOptions.ToConfig(), HoconAddMode.Prepend);
+                return builder.WithJournal(journalOptions, eventAdapterConfigurator);
             }
 
             return builder;
@@ -317,14 +308,7 @@ namespace Akka.Persistence.Azure.Hosting
             if (options is null)
                 throw new ArgumentNullException(nameof(options));
 
-            builder.AddHocon(options.ToConfig(), HoconAddMode.Prepend);
-            options.Apply(builder);
-            builder.AddHocon(options.DefaultConfig, HoconAddMode.Append);
-            
-            // Need to add persistence default settings to make sure that persistence message serializer is loaded properly
-            builder.AddHocon(Persistence.DefaultConfig(), HoconAddMode.Append);
-            
-            return builder;
+            return builder.WithJournal(options, null);
         }
         
         /// <summary>
@@ -584,14 +568,7 @@ namespace Akka.Persistence.Azure.Hosting
             if (options is null)
                 throw new ArgumentNullException(nameof(options));
 
-            builder.AddHocon(options.ToConfig(), HoconAddMode.Prepend);
-            options.Apply(builder);
-            builder.AddHocon(options.DefaultConfig, HoconAddMode.Append);
-            
-            // Need to add persistence default settings to make sure that persistence snapshot message serializer is loaded properly
-            builder.AddHocon(Persistence.DefaultConfig(), HoconAddMode.Append);
-
-            return builder;
+            return builder.WithSnapshot(options, null);
         }
 
         /// <summary>
@@ -617,6 +594,10 @@ namespace Akka.Persistence.Azure.Hosting
         ///     A delegate that can be used to configure an <see cref="AkkaPersistenceJournalBuilder"/> instance
         ///     to set up event adapters.
         /// </param>
+        /// <param name="snapshotBuilder">
+        ///     A delegate that can be used to configure an <see cref="AkkaPersistenceSnapshotBuilder"/> instance
+        ///     to set up snapshot store health checks.
+        /// </param>
         /// <returns>
         ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
         /// </returns>
@@ -626,10 +607,23 @@ namespace Akka.Persistence.Azure.Hosting
             bool autoInitialize = true,
             string containerName = DefaultBlobContainerName,
             string tableName = DefaultTableName,
-            Action<AkkaPersistenceJournalBuilder>? eventAdapterConfigurator = null)
+            Action<AkkaPersistenceJournalBuilder>? eventAdapterConfigurator = null,
+            Action<AkkaPersistenceSnapshotBuilder>? snapshotBuilder = null)
         {
             builder.WithAzureTableJournal(connectionString, autoInitialize, tableName, eventAdapterConfigurator);
             builder.WithAzureBlobsSnapshotStore(connectionString, autoInitialize, containerName);
+
+            // Apply snapshot builder if provided
+            if (snapshotBuilder != null)
+            {
+                var snapshotOptions = new AzureBlobSnapshotOptions(true, "azure-blob-store")
+                {
+                    ConnectionString = connectionString,
+                    AutoInitialize = autoInitialize,
+                    ContainerName = containerName
+                };
+                builder.WithSnapshot(snapshotOptions, snapshotBuilder);
+            }
 
             return builder;
         }
@@ -673,6 +667,10 @@ namespace Akka.Persistence.Azure.Hosting
         ///     A delegate that can be used to configure an <see cref="AkkaPersistenceJournalBuilder"/> instance
         ///     to set up event adapters.
         /// </param>
+        /// <param name="snapshotBuilder">
+        ///     A delegate that can be used to configure an <see cref="AkkaPersistenceSnapshotBuilder"/> instance
+        ///     to set up snapshot store health checks.
+        /// </param>
         /// <returns>
         ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
         /// </returns>
@@ -686,10 +684,25 @@ namespace Akka.Persistence.Azure.Hosting
             bool autoInitialize = true,
             string containerName = DefaultBlobContainerName,
             string tableName = DefaultTableName,
-            Action<AkkaPersistenceJournalBuilder>? eventAdapterConfigurator = null)
+            Action<AkkaPersistenceJournalBuilder>? eventAdapterConfigurator = null,
+            Action<AkkaPersistenceSnapshotBuilder>? snapshotBuilder = null)
         {
             builder.WithAzureTableJournal(tableStorageServiceUri, defaultAzureCredential, tableClientOptions, autoInitialize, tableName, eventAdapterConfigurator);
             builder.WithAzureBlobsSnapshotStore(blobStorageServiceUri, defaultAzureCredential, blobClientOptions, autoInitialize, containerName);
+
+            // Apply snapshot builder if provided
+            if (snapshotBuilder != null)
+            {
+                var snapshotOptions = new AzureBlobSnapshotOptions(true, "azure-blob-store")
+                {
+                    ServiceUri = blobStorageServiceUri,
+                    AzureCredential = defaultAzureCredential,
+                    BlobClientOptions = blobClientOptions,
+                    AutoInitialize = autoInitialize,
+                    ContainerName = containerName
+                };
+                builder.WithSnapshot(snapshotOptions, snapshotBuilder);
+            }
 
             return builder;
         }
@@ -720,6 +733,10 @@ namespace Akka.Persistence.Azure.Hosting
         ///     A delegate that can be used to configure an <see cref="AkkaPersistenceJournalBuilder"/> instance
         ///     to set up event adapters.
         /// </param>
+        /// <param name="snapshotBuilder">
+        ///     A delegate that can be used to configure an <see cref="AkkaPersistenceSnapshotBuilder"/> instance
+        ///     to set up snapshot store health checks.
+        /// </param>
         /// <returns>
         ///     The same <see cref="AkkaConfigurationBuilder"/> instance originally passed in.
         /// </returns>
@@ -730,10 +747,23 @@ namespace Akka.Persistence.Azure.Hosting
             bool autoInitialize = true,
             string containerName = DefaultBlobContainerName,
             string tableName = DefaultTableName,
-            Action<AkkaPersistenceJournalBuilder>? eventAdapterConfigurator = null)
+            Action<AkkaPersistenceJournalBuilder>? eventAdapterConfigurator = null,
+            Action<AkkaPersistenceSnapshotBuilder>? snapshotBuilder = null)
         {
             builder.WithAzureTableJournal(tableServiceClientFactory, autoInitialize, tableName, eventAdapterConfigurator);
             builder.WithAzureBlobsSnapshotStore(blobServiceClientFactory, autoInitialize, containerName);
+
+            // Apply snapshot builder if provided
+            if (snapshotBuilder != null)
+            {
+                var snapshotOptions = new AzureBlobSnapshotOptions(true, "azure-blob-store")
+                {
+                    BlobServiceClientFactory = blobServiceClientFactory,
+                    AutoInitialize = autoInitialize,
+                    ContainerName = containerName
+                };
+                builder.WithSnapshot(snapshotOptions, snapshotBuilder);
+            }
 
             return builder;
         }

--- a/src/Akka.Persistence.Azure.Tests/Hosting/AzurePersistenceHealthCheckSpec.cs
+++ b/src/Akka.Persistence.Azure.Tests/Hosting/AzurePersistenceHealthCheckSpec.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Persistence.Azure.Hosting;
+using Akka.Persistence.Azure.Tests.Helper;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Azure.Tests.Hosting
+{
+    [Collection("AzureSpecs")]
+    public class AzurePersistenceHealthCheckSpec
+    {
+        private readonly ITestOutputHelper _output;
+
+        public AzurePersistenceHealthCheckSpec(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public async Task Journal_health_check_should_be_registered()
+        {
+            // Arrange
+            var conn = Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR") ?? "UseDevelopmentStorage=true";
+            await DbUtils.CleanupCloudTable(conn);
+
+            var host = new HostBuilder()
+                .ConfigureServices(collection =>
+                {
+                    collection.AddAkka("MyActorSys", builder =>
+                    {
+                        builder.WithAzureTableJournal(
+                            connectionString: conn,
+                            eventAdapterConfigurator: journal => journal.WithHealthCheck());
+                    });
+                })
+                .Build();
+
+            await host.StartAsync();
+
+            try
+            {
+                // Act
+                var healthCheckService = host.Services.GetRequiredService<HealthCheckService>();
+                var result = await healthCheckService.CheckHealthAsync();
+
+                // Assert
+                result.Status.Should().Be(HealthStatus.Healthy);
+                result.Entries.Keys.Should().Contain("akka.persistence.journal.azure-table");
+            }
+            finally
+            {
+                await host.StopAsync();
+                host.Dispose();
+            }
+        }
+
+        [Fact]
+        public async Task Snapshot_health_check_should_be_registered()
+        {
+            // Arrange
+            var conn = Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR") ?? "UseDevelopmentStorage=true";
+            await DbUtils.CleanupCloudTable(conn);
+
+            var host = new HostBuilder()
+                .ConfigureServices(collection =>
+                {
+                    collection.AddAkka("MyActorSys", builder =>
+                    {
+                        builder.WithAzurePersistence(
+                            connectionString: conn,
+                            snapshotBuilder: snapshot => snapshot.WithHealthCheck());
+                    });
+                })
+                .Build();
+
+            await host.StartAsync();
+
+            try
+            {
+                // Act
+                var healthCheckService = host.Services.GetRequiredService<HealthCheckService>();
+                var result = await healthCheckService.CheckHealthAsync();
+
+                // Assert
+                result.Status.Should().Be(HealthStatus.Healthy);
+                result.Entries.Keys.Should().Contain("akka.persistence.snapshot-store.azure-blob-store");
+            }
+            finally
+            {
+                await host.StopAsync();
+                host.Dispose();
+            }
+        }
+
+        [Fact]
+        public async Task Both_journal_and_snapshot_health_checks_should_be_registered()
+        {
+            // Arrange
+            var conn = Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR") ?? "UseDevelopmentStorage=true";
+            await DbUtils.CleanupCloudTable(conn);
+
+            var host = new HostBuilder()
+                .ConfigureServices(collection =>
+                {
+                    collection.AddAkka("MyActorSys", builder =>
+                    {
+                        builder.WithAzurePersistence(
+                            connectionString: conn,
+                            eventAdapterConfigurator: journal => journal.WithHealthCheck(),
+                            snapshotBuilder: snapshot => snapshot.WithHealthCheck());
+                    });
+                })
+                .Build();
+
+            await host.StartAsync();
+
+            try
+            {
+                // Act
+                var healthCheckService = host.Services.GetRequiredService<HealthCheckService>();
+                var result = await healthCheckService.CheckHealthAsync();
+
+                // Assert
+                result.Status.Should().Be(HealthStatus.Healthy);
+                result.Entries.Keys.Should().Contain("akka.persistence.journal.azure-table");
+                result.Entries.Keys.Should().Contain("akka.persistence.snapshot-store.azure-blob-store");
+            }
+            finally
+            {
+                await host.StopAsync();
+                host.Dispose();
+            }
+        }
+
+        [Fact]
+        public async Task Health_check_with_custom_degraded_status_should_work()
+        {
+            // Arrange
+            var conn = Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR") ?? "UseDevelopmentStorage=true";
+            await DbUtils.CleanupCloudTable(conn);
+
+            var host = new HostBuilder()
+                .ConfigureServices(collection =>
+                {
+                    collection.AddAkka("MyActorSys", builder =>
+                    {
+                        builder.WithAzurePersistence(
+                            connectionString: conn,
+                            eventAdapterConfigurator: journal => journal.WithHealthCheck(HealthStatus.Degraded),
+                            snapshotBuilder: snapshot => snapshot.WithHealthCheck(HealthStatus.Degraded));
+                    });
+                })
+                .Build();
+
+            await host.StartAsync();
+
+            try
+            {
+                // Act
+                var healthCheckService = host.Services.GetRequiredService<HealthCheckService>();
+                var result = await healthCheckService.CheckHealthAsync();
+
+                // Assert
+                // Health checks should be registered and report as healthy (degraded status is for failures)
+                result.Status.Should().Be(HealthStatus.Healthy);
+                result.Entries.Keys.Should().Contain("akka.persistence.journal.azure-table");
+                result.Entries.Keys.Should().Contain("akka.persistence.snapshot-store.azure-blob-store");
+            }
+            finally
+            {
+                await host.StopAsync();
+                host.Dispose();
+            }
+        }
+
+        [Fact]
+        public async Task Health_checks_should_pass_after_persistence_operations()
+        {
+            // Arrange
+            var conn = Environment.GetEnvironmentVariable("AZURE_CONNECTION_STR") ?? "UseDevelopmentStorage=true";
+            await DbUtils.CleanupCloudTable(conn);
+
+            var host = new HostBuilder()
+                .ConfigureServices(collection =>
+                {
+                    collection.AddAkka("MyActorSys", builder =>
+                    {
+                        builder.WithAzurePersistence(
+                            connectionString: conn,
+                            eventAdapterConfigurator: journal => journal.WithHealthCheck(),
+                            snapshotBuilder: snapshot => snapshot.WithHealthCheck());
+
+                        builder.StartActors((system, registry) =>
+                        {
+                            var myActor = system.ActorOf(Props.Create(() => new MyPersistenceActor("health-check-test")), "test-actor");
+                            registry.Register<MyPersistenceActor>(myActor);
+                        });
+                    });
+                })
+                .Build();
+
+            await host.StartAsync();
+
+            try
+            {
+                var actorRegistry = host.Services.GetRequiredService<ActorRegistry>();
+                var myPersistentActor = actorRegistry.Get<MyPersistenceActor>();
+
+                // Act - perform persistence operations
+                var resp1 = await myPersistentActor.Ask<string>(1, TimeSpan.FromSeconds(5));
+                var resp2 = await myPersistentActor.Ask<string>(2, TimeSpan.FromSeconds(5));
+                resp1.Should().Be("ACK");
+                resp2.Should().Be("ACK");
+
+                // Now check health
+                var healthCheckService = host.Services.GetRequiredService<HealthCheckService>();
+                var result = await healthCheckService.CheckHealthAsync();
+
+                // Assert
+                result.Status.Should().Be(HealthStatus.Healthy);
+                result.Entries.Keys.Should().Contain("akka.persistence.journal.azure-table");
+                result.Entries.Keys.Should().Contain("akka.persistence.snapshot-store.azure-blob-store");
+
+                // Verify individual entries are healthy
+                result.Entries["akka.persistence.journal.azure-table"].Status.Should().Be(HealthStatus.Healthy);
+                result.Entries["akka.persistence.snapshot-store.azure-blob-store"].Status.Should().Be(HealthStatus.Healthy);
+
+                // Verify data and descriptions exist
+                result.Entries["akka.persistence.journal.azure-table"].Data.Should().NotBeNull();
+                result.Entries["akka.persistence.snapshot-store.azure-blob-store"].Data.Should().NotBeNull();
+            }
+            finally
+            {
+                await host.StopAsync();
+                host.Dispose();
+            }
+        }
+
+        public sealed class MyPersistenceActor : ReceivePersistentActor
+        {
+            private List<int> _values = new List<int>();
+
+            public MyPersistenceActor(string persistenceId)
+            {
+                PersistenceId = persistenceId;
+
+                Recover<SnapshotOffer>(offer =>
+                {
+                    if (offer.Snapshot is IEnumerable<int> ints)
+                    {
+                        _values = new List<int>(ints);
+                    }
+                });
+
+                Recover<int>(i => { _values.Add(i); });
+
+                Command<int>(i =>
+                {
+                    Persist(i, i1 =>
+                    {
+                        _values.Add(i);
+                        if (LastSequenceNr % 2 == 0)
+                        {
+                            SaveSnapshot(_values);
+                        }
+
+                        Sender.Tell("ACK");
+                    });
+                });
+
+                Command<string>(str => str.Equals("getall"), s => { Sender.Tell(_values.ToArray()); });
+
+                Command<SaveSnapshotSuccess>(s => { });
+            }
+
+            public override string PersistenceId { get; }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR addresses critical issues in the Akka.Persistence.Azure.Hosting extension methods that prevented health checks from being properly registered and utilized the deprecated manual HOCON manipulation pattern instead of the unified Akka.Hosting API introduced in v1.5.51.

## Problems Fixed

1. **Health checks never registered** - `AkkaPersistenceJournalBuilder` was created and configured but `.Build()` was never called, preventing health check registration
2. **No snapshot store health check support** - Missing `Action<AkkaPersistenceSnapshotBuilder>` parameters  
3. **Manual HOCON manipulation** - Used outdated pattern instead of `.WithJournal()` and `.WithSnapshot()` unified API

## Changes

### AzurePersistenceExtensions.cs

**Journal Methods Updated:**
- `WithAzureTableJournal(TableServiceClient)` - Now uses `builder.WithJournal(options, eventAdapterConfigurator)`
- `WithAzureTableJournal(Uri, TokenCredential)` - Same pattern
- `WithAzureTableJournal(connectionString)` - Same pattern
- `WithAzureTableJournal(Setup, eventAdapter)` - Delegates to unified API when adapter configurator provided
- Bottom-level `WithAzureTableJournal(Options)` - Replaced manual HOCON with `builder.WithJournal()`

**Snapshot Methods Updated:**
- Bottom-level `WithAzureBlobsSnapshotStore(Options)` - Replaced manual HOCON with `builder.WithSnapshot()`

**New Snapshot Builder Support:**
- Added `Action<AkkaPersistenceSnapshotBuilder>? snapshotBuilder` parameter to all three `WithAzurePersistence` overloads

### AzurePersistenceHealthCheckSpec.cs (New)

Comprehensive test suite validating:
- Journal health check registration
- Snapshot store health check registration
- Both health checks working together
- Custom health status configuration
- Health checks pass after real persistence operations

## Benefits

✅ Health checks now properly registered and functional  
✅ Snapshot store health checks supported  
✅ Uses modern Akka.Hosting unified API (consistent with other persistence plugins)  
✅ No breaking changes (all existing signatures preserved, new parameters optional)  
✅ Event adapters continue to work (backward compatible)

## Test Plan

- [x] All existing tests pass
- [x] New health check tests created and pass
- [x] Build succeeds without warnings
- [x] No breaking API changes

## Wire Compatibility

No breaking changes - only internal implementation changes and optional parameter additions at method signature ends.